### PR TITLE
Fixes

### DIFF
--- a/Interstation-Two-WW2/code/game/objects/items/weapons/storage/storage.dm
+++ b/Interstation-Two-WW2/code/game/objects/items/weapons/storage/storage.dm
@@ -79,16 +79,24 @@
 				usr.put_in_l_hand(src)*/
 
 		if (istype(over_object, /obj/screen/inventory/hand))
-			var/obj/screen/inventory/hand/H = over_object
-			switch(H.slot_id)
-				if(slot_r_hand)
-					usr.u_equip(src)
-					usr.put_in_r_hand(src)
-				if(slot_l_hand)
-					usr.u_equip(src)
-					usr.put_in_l_hand(src)
-
-
+			if( !usr.get_active_hand() )
+				var/obj/screen/inventory/hand/H = over_object
+				switch(H.slot_id)
+					if(slot_r_hand)
+						if(!usr.r_hand)
+							usr.u_equip(src)
+							usr.put_in_r_hand(src)
+						else
+							usr << "<span class='notice'>Your right hand is already holding the [usr.r_hand].</span>"
+					if(slot_l_hand)
+						if(!usr.l_hand)
+							usr.u_equip(src)
+							usr.put_in_l_hand(src)
+						else
+							usr << "<span class='notice'>Your left hand is already holding the [usr.l_hand].</span>"
+			else
+				usr << "<span class='notice'>Your hand is too busy to grab the [src].</span>"
+				
 		src.add_fingerprint(usr)
 
 

--- a/Interstation-Two-WW2/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/Interstation-Two-WW2/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -205,8 +205,8 @@
 			if(istype(affecting, /obj/item/organ/external/head) && prob(hitcheck * (hit_zone == "mouth" ? 5 : 1))) //MUCH higher chance to knock out teeth if you aim for mouth
 				var/obj/item/organ/external/head/U = affecting
 				if(U.knock_out_teeth(get_dir(H, src), round(rand(28, 38) * ((hitcheck*2)/100))))
-					src.visible_message("<span class='danger'>[src]'s teeth sail off in an arc!</span>", \
-										"<span class='userdanger'>[src]'s teeth sail off in an arc!</span>")
+					src.visible_message("<span class='danger'>Some of [src]'s teeth sail off in an arc!</span>", \
+										"<span class='userdanger'>Some of [src]'s teeth sail off in an arc!</span>")
 
 			// See what attack they use
 			var/datum/unarmed_attack/attack = H.get_unarmed_attack(src, hit_zone)

--- a/Interstation-Two-WW2/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/Interstation-Two-WW2/code/modules/mob/living/carbon/human/human_defense.dm
@@ -214,8 +214,8 @@ meteor_act
 	var/obj/item/organ/external/head/O = locate(/obj/item/organ/external/head) in src.organs
 	if(prob(I.force * (hit_zone == "mouth" ? 5 : 0)) && O) //Will the teeth fly out?
 		if(O.knock_out_teeth(get_dir(user, src), round(rand(28, 38) * ((I.force*1.5)/100))))
-			src.visible_message("<span class='danger'>[src]'s teeth sail off in an arc!</span>", \
-								"<span class='userdanger'>[src]'s teeth sail off in an arc!</span>")
+			src.visible_message("<span class='danger'>Some of [src]'s teeth sail off in an arc!</span>", \
+								"<span class='userdanger'>Some of [src]'s teeth sail off in an arc!</span>")
 		//Apply blood
 		if(!(I.flags & NOBLOODY))
 			I.add_blood(src)

--- a/Interstation-Two-WW2/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/Interstation-Two-WW2/code/modules/projectiles/guns/projectile/automatic.dm
@@ -209,8 +209,8 @@
 	accuracy = -8
 
 	firemodes = list(
-		list(mode_name="short bursts",	burst=5, move_delay=6, burst_accuracy = list(0,-1,-1,-2,-2),          dispersion = list(0.6, 1.0, 1.0, 1.0, 1.2)),
-		list(mode_name="long bursts",	burst=8, move_delay=8, burst_accuracy = list(0,-1,-1,-2,-2,-2,-3,-3), dispersion = list(1.0, 1.0, 1.0, 1.0, 1.2)),
+		list(name="short bursts",	burst=5, move_delay=6, burst_accuracy = list(0,-1,-1,-2,-2),          dispersion = list(0.6, 1.0, 1.0, 1.0, 1.2)),
+		list(name="long bursts",	burst=8, move_delay=8, burst_accuracy = list(0,-1,-1,-2,-2,-2,-3,-3), dispersion = list(1.0, 1.0, 1.0, 1.0, 1.2)),
 		)
 
 	var/cover_open = 0


### PR DESCRIPTION
Tweaks the message displayed when someone's teeth get knocked out to be more grammatically correct.

Fixes the "default" firemode message when changing the firemode of the MG34.

Fixes backpacks vanishing if you drag them from your back into an occupied hand.