### PR TITLE
Removes gas shells from standard issue artillery crate.

### DIFF
--- a/Interstation-Two-WW2/code/modules/WW2/artillery/crate.dm
+++ b/Interstation-Two-WW2/code/modules/WW2/artillery/crate.dm
@@ -7,15 +7,8 @@
 
 	New()
 		..()
-		for (var/v in 1 to 20)
+		for (var/v in 1 to 30)
 			new/obj/item/artillery_ammo(src)
-		for (var/v in 1 to 3)
-			new/obj/item/artillery_ammo/gaseous/green_cross/chlorine(src)
-		for (var/v in 1 to 2)
-			new/obj/item/artillery_ammo/gaseous/yellow_cross/mustard(src)
-			new/obj/item/artillery_ammo/gaseous/yellow_cross/white_phosphorus(src)
-		for (var/v in 1 to 4)
-			new/obj/item/artillery_ammo/gaseous/blue_cross/xylyl_bromide(src)
 
 /obj/structure/closet/crate/gasmasks
 	name = "Gasmask crate"


### PR DESCRIPTION
Gas was never used in this fashion on this front in the war.  Additionally with the current extreme asymmetry of artillery weapons it presents a major balance concern.