### PR TITLE
Adds doctor roles

### DIFF
--- a/Interstation-Two-WW2/code/modules/WW2/apparel.dm
+++ b/Interstation-Two-WW2/code/modules/WW2/apparel.dm
@@ -58,7 +58,7 @@
 	icon_state = "newssuni"
 	item_state = "newssuni"
 	worn_state = "newssuni"
-	
+
 /obj/item/clothing/under/ssformalofc
 	name = "SS Officer's Formal Uniform"
 	desc = "Jet black formal uniform. Swastika armband included."
@@ -148,3 +148,9 @@
 	new /obj/item/ammo_magazine/kar98k(src)
 	new /obj/item/weapon/gauze_pack/gauze(src)
 	new /obj/item/weapon/grenade/explosive/stgnade(src)
+
+/obj/item/clothing/under/doctor
+	desc = "A classy suit for doctors of the 40's."
+	name = "doctor's uniform"
+	icon_state = "ba_suit"
+	item_state = "ba_suit"

--- a/Interstation-Two-WW2/code/modules/WW2/jobs/german.dm
+++ b/Interstation-Two-WW2/code/modules/WW2/jobs/german.dm
@@ -43,7 +43,7 @@
 
 /datum/job/german/commander/get_keys()
 	return list(new/obj/item/weapon/key/german, new/obj/item/weapon/key/german/soldat, new/obj/item/weapon/key/german/medic, new/obj/item/weapon/key/german/engineer,
-		new/obj/item/weapon/key/german/QM, new/obj/item/weapon/key/german/command_intermediate, new/obj/item/weapon/key/german/command_high, new/obj/item/weapon/key/german/train, new/obj/item/weapon/key/german/SS)
+		new/obj/item/weapon/key/german/QM, new/obj/item/weapon/key/german/command_intermediate, new/obj/item/weapon/key/german/command_high, new/obj/item/weapon/key/german/train)
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -176,6 +176,45 @@
 
 /datum/job/german/medic/get_keys()
 	return list(new/obj/item/weapon/key/german, new/obj/item/weapon/key/german/soldat, new/obj/item/weapon/key/german/medic)
+
+/datum/job/german/doctor
+	title = "Medizinier"
+	en_meaning = "Doctor"
+	flag = GERMED
+	department_flag = MEDSCI
+	faction = "Station"
+	total_positions = 2
+	spawn_positions = 2
+	selection_color = "#4c4ca5"
+	access = list(access_nato_soldier, access_nato_medic)
+	minimal_access = list(access_nato_soldier, access_nato_medic)
+	spawn_location = "JoinLateNATO"
+
+/datum/job/german/doctor/equip(var/mob/living/carbon/human/H)
+	if(!H)	return 0
+
+	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/color/white(H), slot_shoes)
+	H.equip_to_slot_or_del(new /obj/item/clothing/under/doctor(H), slot_w_uniform)
+	H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel_med(H), slot_back)
+	H.equip_to_slot_or_del(new /obj/item/clothing/gloves/latex(H), slot_gloves)
+	H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/medical(H), slot_belt)
+	H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/toggle/labcoat(H), slot_wear_suit)
+	H.equip_to_slot_or_del(new /obj/item/weapon/storage/firstaid/adv(H), slot_l_hand)
+	H << "<span class = 'notice'>You are the <b>[title]</b>, a doctor. Your job is to stay back at base and treat wounded that come in from the front, as well as treat prisoners and base personnel.</span>"
+	return 1
+
+/datum/job/german/doctor/get_keys()
+	return list(new/obj/item/weapon/key/german, new/obj/item/weapon/key/german/medic, new/obj/item/weapon/key/german/command_intermediate)
+
+/datum/job/german/doctor/update_character(var/mob/living/carbon/human/H)
+	H.add_language("German")
+	H.default_language = all_languages["German"]
+	if(prob(5))
+		H.add_language("Russian")
+		H << "<b>You know the Russian language!</b>"
+
+	if (istype(H.languages[1], /datum/language/common))
+		H.languages[1] = null
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Interstation-Two-WW2/code/modules/WW2/jobs/russian.dm
+++ b/Interstation-Two-WW2/code/modules/WW2/jobs/russian.dm
@@ -133,6 +133,45 @@
 	return list(new/obj/item/weapon/key/russian, new/obj/item/weapon/key/russian/soldat,
 		new/obj/item/weapon/key/russian/medic)
 
+/datum/job/russian/doctor
+	title = "Doktor"
+	en_meaning = "Doctor"
+	flag = ENGINEER
+	department_flag = ENGSEC
+	faction = "Station"
+	total_positions = 2
+	spawn_positions = 2
+	selection_color = "#770e0e"
+	access = list(access_ru_soldier, access_ru_medic)
+	minimal_access = list(access_ru_soldier, access_ru_medic)
+	spawn_location = "JoinLateRussia"
+
+/datum/job/russian/doctor/equip(var/mob/living/carbon/human/H)
+	if(!H)	return 0
+
+	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/color/white(H), slot_shoes)
+	H.equip_to_slot_or_del(new /obj/item/clothing/under/doctor(H), slot_w_uniform)
+	H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel_med(H), slot_back)
+	H.equip_to_slot_or_del(new /obj/item/clothing/gloves/latex(H), slot_gloves)
+	H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/medical(H), slot_belt)
+	H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/toggle/labcoat(H), slot_wear_suit)
+	H.equip_to_slot_or_del(new /obj/item/weapon/storage/firstaid/adv(H), slot_l_hand)
+	H << "<span class = 'notice'>You are the <b>[title]</b>, a doctor. Your job is to stay back at base and treat wounded that come in from the front, as well as treat prisoners and base personnel.</span>"
+	return 1
+
+/datum/job/russian/doctor/get_keys()
+	return list(new/obj/item/weapon/key/russian, new/obj/item/weapon/key/russian/medic, new/obj/item/weapon/key/russian/command_intermediate)
+
+/datum/job/russian/doctor/update_character(var/mob/living/carbon/human/H)
+	H.add_language("Russian")
+	H.default_language = all_languages["Russian"]
+	if(prob(5))
+		H.add_language("German")
+		H << "<b>You know the German language!</b>"
+
+	if (istype(H.languages[1], /datum/language/common))
+		H.languages[1] = null
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -435,8 +474,8 @@ var/first_guard = 0
 	return 1
 
 /datum/job/russian/zavhoz/update_character(var/mob/living/carbon/human/H)
-	H.add_language("Russian")
 	H.add_language("German")
+	H.add_language("Russian")
 	H.default_language = all_languages["Rusian"]
 	H << "<b>You know the German language!</b>"
 


### PR DESCRIPTION
Adds Medizinier and Doktor roles for Germans and Russians respectively. Their role is to basically stay behind and treat wounded at base while the medics treat them in the field and bring them back.

![image](https://user-images.githubusercontent.com/6334647/28046197-97e4b5d2-65a7-11e7-90e5-429f046a0eb9.png)

Surgical smock sprite is from Baystation12.