### PR TITLE
Macro and Barbed wire Nerf 

### DIFF
--- a/Interstation-Two-WW2/code/modules/WW2/barbwire.dm
+++ b/Interstation-Two-WW2/code/modules/WW2/barbwire.dm
@@ -42,11 +42,11 @@
 				var/obj/item/organ/external/affecting = H.get_organ(pick("l_foot", "r_foot", "l_leg", "r_leg"))
 				if(affecting.status & ORGAN_ROBOT)
 					return
-				if(affecting.take_damage(10, 0))
+				if(affecting.take_damage(5, 0))
 					H.UpdateDamageIcon()
 				H.updatehealth()
 				if(!(H.species && (H.species.flags)))
-					H.Weaken(3)
+					H.Weaken(2)
 				M << "\red <B>Your [affecting.name] gets slightly cut by \the [src]!</B>"
 				return ..()
 			if (prob (33))
@@ -54,11 +54,11 @@
 				var/obj/item/organ/external/affecting = H.get_organ(pick("l_foot", "r_foot", "l_leg", "r_leg"))
 				if(affecting.status & ORGAN_ROBOT)
 					return
-				if(affecting.take_damage(20, 0))
+				if(affecting.take_damage(10, 0))
 					H.UpdateDamageIcon()
 				H.updatehealth()
 				if(!(H.species && (H.species.flags)))
-					H.Weaken(5)
+					H.Weaken(4)
 				M << "\red <B>Your [affecting.name] gets cut by \the [src]!</B>"
 				return ..()
 			if (prob (33))
@@ -66,11 +66,11 @@
 				var/obj/item/organ/external/affecting = H.get_organ(pick("l_foot", "r_foot", "l_leg", "r_leg"))
 				if(affecting.status & ORGAN_ROBOT)
 					return
-				if(affecting.take_damage(30, 0))
+				if(affecting.take_damage(15, 0))
 					H.UpdateDamageIcon()
 				H.updatehealth()
 				if(!(H.species && (H.species.flags)))
-					H.Weaken(7)
+					H.Weaken(5)
 				M << "\red <B>Your [affecting.name] gets deeply cut by \the [src]!</B>"
 				return ..()
 	..()

--- a/Interstation-Two-WW2/interface/interface.dm
+++ b/Interstation-Two-WW2/interface/interface.dm
@@ -63,6 +63,8 @@ Hotkey-Mode: (hotkey-mode must be on)
 \tt = say
 \t5 = emote
 \tx = swap-hand
+\tspace = Use-iron-sights
+\t, = rest
 \tz = activate held object (or y)
 \tj = toggle-aiming-mode
 \tf = cycle-intents-left
@@ -115,6 +117,8 @@ Hotkey-Mode: (hotkey-mode must be on)
 \tw = up
 \tq = unequip active module
 \tt = say
+\tspace = Use-iron-sights
+\t, = rest
 \tx = cycle active modules
 \tz = activate held object (or y)
 \tf = cycle-intents-left

--- a/Interstation-Two-WW2/interface/skin.dmf
+++ b/Interstation-Two-WW2/interface/skin.dmf
@@ -197,6 +197,12 @@ macro "borghotkeymode"
 	elem 
 		name = "F12"
 		command = "F12"
+	elem
+		name = "space"
+		command = "Use-iron-sights"
+	elem
+		name = ","
+		command = "rest"
 
 macro "macro"
 	elem 


### PR DESCRIPTION
Added two new macros and decreased damage done by barbed wire. At least now it does not ruin a round by destroying your leg.