### PR TITLE
Adds a remove empty bullet casings from map verb

### DIFF
--- a/Interstation-Two-WW2/code/global.dm
+++ b/Interstation-Two-WW2/code/global.dm
@@ -13,6 +13,7 @@ var/global/list/active_diseases          = list()
 var/global/list/med_hud_users            = list() // List of all entities using a medical HUD.
 var/global/list/sec_hud_users            = list() // List of all entities using a security HUD.
 var/global/list/hud_icon_reference       = list()
+var/global/list/bullet_casings			 = list()
 
 var/list/init_lights = list()
 

--- a/Interstation-Two-WW2/code/modules/admin/verbs/debug.dm
+++ b/Interstation-Two-WW2/code/modules/admin/verbs/debug.dm
@@ -876,3 +876,18 @@
 		log_admin("[key_name(src)] has toggled [M.key]'s [blockname] block [state]!")
 	else
 		alert("Invalid mob")
+
+/client/proc/removeEmptyCases()
+	set category = "Debug"
+	set name = "Remove empty bullet casings"
+	set desc = "Removes ALL empty bullet casings from the map"
+
+	for(var/A in bullet_casings)
+		var/obj/item/ammo_casing/B = A
+		if(B.BB)
+			continue
+		qdel(B)
+	log_admin("[key_name(usr)] has removed all empty bullet casings.")
+	message_admins("<span class='notice'>[key_name_admin(usr)] has removed all empty bullet casings.</span>", 1)
+
+

--- a/Interstation-Two-WW2/code/modules/admin/verbs/debug.dm
+++ b/Interstation-Two-WW2/code/modules/admin/verbs/debug.dm
@@ -890,4 +890,18 @@
 	log_admin("[key_name(usr)] has removed all empty bullet casings.")
 	message_admins("<span class='notice'>[key_name_admin(usr)] has removed all empty bullet casings.</span>", 1)
 
+/client/proc/removeHalfEmptyCases()
+	set category = "Debug"
+	set name = "Remove half of empty bullet casings"
+	set desc = "Removes half of the empty bullet casings from the map"
 
+	var/limit = bullet_casings.len/2
+	var/counter = 0
+	for(var/A in bullet_casings)
+		var/obj/item/ammo_casing/B = A
+		if(B.BB || counter > limit)
+			continue
+		counter ++
+		qdel(B)
+	log_admin("[key_name(usr)] has removed half of all empty bullet casings.")
+	message_admins("<span class='notice'>[key_name_admin(usr)] has removed half of all empty bullet casings.</span>", 1)

--- a/Interstation-Two-WW2/code/modules/projectiles/ammunition.dm
+++ b/Interstation-Two-WW2/code/modules/projectiles/ammunition.dm
@@ -20,6 +20,12 @@
 		BB = new projectile_type(src)
 	pixel_x = rand(-10, 10)
 	pixel_y = rand(-10, 10)
+	bullet_casings += src
+
+
+/obj/item/ammo_casing/Destroy()
+	bullet_casings -= src
+	return ..()
 
 //removes the projectile from the ammo casing
 /obj/item/ammo_casing/proc/expend()

--- a/Interstation-Two-WW2/code/modules/projectiles/ammunition.dm
+++ b/Interstation-Two-WW2/code/modules/projectiles/ammunition.dm
@@ -22,7 +22,6 @@
 	pixel_y = rand(-10, 10)
 	bullet_casings += src
 
-
 /obj/item/ammo_casing/Destroy()
 	bullet_casings -= src
 	return ..()


### PR DESCRIPTION
Adds a verb to the debug tab so admins/devs/whoever can remove all empty casings from the map.

 (Ignore the branch name. This was going to be a barb wire PR but I changed my mind)