### PR TITLE
Fixes a major issue related to zoom and lying down

### DIFF
--- a/Interstation-Two-WW2/Interstation-Two-WW2.dme
+++ b/Interstation-Two-WW2/Interstation-Two-WW2.dme
@@ -1212,6 +1212,7 @@
 #include "code\modules\mob\mob_helpers.dm"
 #include "code\modules\mob\mob_movement.dm"
 #include "code\modules\mob\mob_transformation_simple.dm"
+#include "code\modules\mob\mob_view.dm"
 #include "code\modules\mob\say.dm"
 #include "code\modules\mob\transform_procs.dm"
 #include "code\modules\mob\typing_indicator.dm"

--- a/Interstation-Two-WW2/code/game/objects/items.dm
+++ b/Interstation-Two-WW2/code/game/objects/items.dm
@@ -228,7 +228,7 @@
 // apparently called whenever an item is removed from a slot, container, or anything else.
 /obj/item/proc/dropped(mob/user as mob)
 	..()
-	if(zoom) zoom() //binoculars, scope, etc
+	if(zoom) zoom(user) //binoculars, scope, etc
 
 // called just as an item is picked up (loc is not yet changed)
 /obj/item/proc/pickup(mob/user)
@@ -567,7 +567,7 @@ var/list/global/slot_flags_enumeration = list(
 //	devicename: name of what device you are peering through, set by zoom() in items.dm
 //	silent: boolean controlling whether it should tell the user why they can't zoom in or not
 // I am sorry for creating this abomination -- Irra
-/obj/item/proc/can_zoom(mob/user, var/devicename = src.name, var/silent = 0)
+/obj/item/proc/can_zoom(mob/living/user, var/devicename = src.name, var/silent = 0)
 	if(user.stat || !ishuman(user))
 		if (!silent) user << "You are unable to focus through the [devicename]"
 		return 0
@@ -585,7 +585,10 @@ modules/mob/mob_movement.dm if you move you will be zoomed out
 modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 */
 //Looking through a scope or binoculars should /not/ improve your periphereal vision. Still, increase viewsize a tiny bit so that sniping isn't as restricted to NSEW
-/obj/item/proc/zoom(var/tileoffset = 14, var/viewsize = 9) //tileoffset is client view offset in the direction the user is facing. viewsize is how far out this thing zooms. 7 is normal view
+/obj/item/proc/zoom(var/mob/user, var/tileoffset = 14, var/viewsize = 9) //tileoffset is client view offset in the direction the user is facing. viewsize is how far out this thing zooms. 7 is normal view
+	if (!user)
+		return 0
+
 	var/devicename
 
 	if(zoomdevicename)
@@ -593,46 +596,42 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 	else
 		devicename = src.name
 
-	var/cannotzoom = !can_zoom(usr, devicename)
+	var/cannotzoom = !can_zoom(user, devicename)
 
 	if(!zoom && !cannotzoom)
 		//if(usr.hud_used.hud_shown)
 			//usr.toggle_zoom_hud()	// If the user has already limited their HUD this avoids them having a HUD when they zoom in
-		usr.client.view = viewsize
+		user.client.view = viewsize
 		zoom = 1
 
 		var/tilesize = 32
 		var/viewoffset = tilesize * tileoffset
 
-		switch(usr.dir)
+		switch(user.dir)
 			if (NORTH)
-				usr.client.pixel_x = 0
-				usr.client.pixel_y = viewoffset
+				user.client.pixel_x = 0
+				user.client.pixel_y = viewoffset
 			if (SOUTH)
-				usr.client.pixel_x = 0
-				usr.client.pixel_y = -viewoffset
+				user.client.pixel_x = 0
+				user.client.pixel_y = -viewoffset
 			if (EAST)
-				usr.client.pixel_x = viewoffset
-				usr.client.pixel_y = 0
+				user.client.pixel_x = viewoffset
+				user.client.pixel_y = 0
 			if (WEST)
-				usr.client.pixel_x = -viewoffset
-				usr.client.pixel_y = 0
+				user.client.pixel_x = -viewoffset
+				user.client.pixel_y = 0
 
-		usr.visible_message("[usr] peers through the [zoomdevicename ? "[zoomdevicename] of the [src.name]" : "[src.name]"].")
+		user.visible_message("[user] peers through the [zoomdevicename ? "[zoomdevicename] of the [src.name]" : "[src.name]"].")
 
 	else
-		usr.client.view = world.view
-		//if(!usr.hud_used.hud_shown)
-			//usr.toggle_zoom_hud()
 		zoom = 0
 
-		usr.client.pixel_x = 0
-		usr.client.pixel_y = 0
+		user.reset_zoom() // IT IS NOT THE SAME AS "reset_view"!
 
 		if(!cannotzoom)
-			usr.visible_message("[zoomdevicename ? "[usr] looks up from the [src.name]" : "[usr] lowers the [src.name]"].")
+			user.visible_message("[zoomdevicename ? "[user] looks up from the [src.name]" : "[user] lowers the [src.name]"].")
 
-	return
+	return 1
 
 /obj/item/proc/pwr_drain()
 	return 0 // Process Kill

--- a/Interstation-Two-WW2/code/modules/WW2/weapons/guns/bolt-action.dm
+++ b/Interstation-Two-WW2/code/modules/WW2/weapons/guns/bolt-action.dm
@@ -62,7 +62,7 @@
 	set name = "Use Scope"
 	set popup_menu = 1
 
-	toggle_scope(2.0)
+	toggle_scope(usr, 2.0)
 
 /obj/item/weapon/gun/projectile/boltaction/kar98k
 	name = "Kar98k rifle"
@@ -126,4 +126,4 @@
 	set name = "Use Scope"
 	set popup_menu = 1
 
-	toggle_scope(2.2)
+	toggle_scope(usr, 2.2)

--- a/Interstation-Two-WW2/code/modules/WW2/weapons/guns/stationary.dm
+++ b/Interstation-Two-WW2/code/modules/WW2/weapons/guns/stationary.dm
@@ -58,15 +58,15 @@
 			if(user.has_empty_hand(both = 1) && !src.is_used_by(user))
 				user.use_object(src)
 			else
-				user << "\red Your hands are busy by holding things."
+				user.show_message("\red Your hands are busy by holding things.")
 		else
-			user << "\red You're too far from the handles."
+			user.show_message("\red You're too far from the handles.")
 
 /obj/item/weapon/gun/projectile/minigun/proc/try_use_sights(mob/user)
 	if (src.is_used_by(user))
-		toggle_scope(2.0)
+		toggle_scope(usr, 2.0)
 	else
-		user.visible_message("<span class='warning'>You aren't using \the [src].</span>")
+		user.show_message("<span class='warning'>You aren't using \the [src].</span>")
 
 
 // An ugly hack called a boolean proc, made it like this to allow special
@@ -78,10 +78,10 @@
 // I am sorry for creating this abomination -- Irra
 /obj/item/weapon/gun/projectile/minigun/can_zoom(mob/user, var/devicename, var/silent)
 	if(user.stat || !ishuman(user))
-		if (!silent) user << "You are unable to focus through the [devicename]"
+		if (!silent) user.show_message("You are unable to focus through the [devicename]")
 		return 0
 	else if(!zoom && global_hud.darkMask[1] in user.client.screen)
-		if (!silent) user << "Your visor gets in the way of looking through the [devicename]"
+		if (!silent) user.show_message("Your visor gets in the way of looking through the [devicename]")
 		return 0
 	return 1
 
@@ -90,9 +90,9 @@
 		if (user.has_empty_hand())
 			src.unload_ammo(user)
 		else
-			user.visible_message("<span class='warning'>You need an empty hand for this.</span>")
+			user.show_message("<span class='warning'>You need an empty hand for this.</span>")
 	else
-		user.visible_message("<span class='warning'>You can't do this while using \the [src].</span>")
+		user.show_message("<span class='warning'>You can't do this while using \the [src].</span>")
 
 /obj/item/weapon/gun/projectile/minigun/proc/usedby(mob/user, atom/A, params)
 	if(A == src)
@@ -116,7 +116,7 @@
 	return 1
 
 /obj/item/weapon/gun/projectile/minigun/proc/rotate_to(mob/user, atom/A)
-	user << "<span class='warning'>You can't turn the [name] there.</span>"
+	user.show_message("<span class='warning'>You can't turn the [name] there.</span>")
 	return 0
 
 /obj/item/weapon/gun/projectile/minigun/proc/update_layer()
@@ -151,7 +151,7 @@
 //	if (user_old_x && user_old_y)
 		//animate(user, pixel_x=user_old_x, pixel_y=user_old_y, 4, 1)
 	if (zoom)
-		zoom() // out
+		zoom(user) // out
 
 	user.pixel_x = user_old_x
 	user.pixel_y = user_old_y

--- a/Interstation-Two-WW2/code/modules/mob/mob_view.dm
+++ b/Interstation-Two-WW2/code/modules/mob/mob_view.dm
@@ -1,0 +1,10 @@
+// used to be called "reset_view" before we realized it already existed, but its
+// only purpose was to reset the eye and HUD overlays - what the fuck guys?
+// you really need to get better at nomenclature, I guess
+/mob/proc/reset_zoom()
+	if (client)
+		client.view = world.view
+		client.pixel_x = 0
+		client.pixel_y = 0
+		return 1
+	return 0

--- a/Interstation-Two-WW2/code/modules/mob/use_object.dm
+++ b/Interstation-Two-WW2/code/modules/mob/use_object.dm
@@ -8,13 +8,21 @@
 			mg.usedby(src, mg)
 			mg.started_using(src)
 
-/mob/Move()
-	. = ..()
+/mob/proc/handle_object_operation(var/stop_using = 0)
 	if (using_object)
 		if (istype(using_object, /obj/item/weapon/gun/projectile/minigun))
 			var/obj/item/weapon/gun/projectile/minigun/mg = using_object
-			if (!locate(src) in range(mg.maximum_use_range, mg))
+			if (!(locate(src) in range(mg.maximum_use_range, mg)) || stop_using)
 				use_object(null)
 				mg.stopped_using(src)
-		else if (!locate(using_object) in range(1, src))
+		else if (!locate(using_object) in range(1, src) || stop_using)
 			use_object(null)
+
+/mob/Move()
+	. = ..()
+	handle_object_operation()
+
+/mob/update_canmove()
+	. = ..()
+	if (lying || stat)
+		handle_object_operation(stop_using = 1)

--- a/Interstation-Two-WW2/code/modules/projectiles/gun.dm
+++ b/Interstation-Two-WW2/code/modules/projectiles/gun.dm
@@ -497,14 +497,14 @@
 		mouthshoot = 0
 		return
 
-/obj/item/weapon/gun/proc/toggle_scope(var/zoom_amount=2.0)
+/obj/item/weapon/gun/proc/toggle_scope(mob/living/user, var/zoom_amount=2.0)
 	//looking through a scope limits your periphereal vision
 	//still, increase the view size by a tiny amount so that sniping isn't too restricted to NSEW
 	var/zoom_offset = round(world.view * zoom_amount)
 	var/view_size = round(world.view + zoom_amount)
 	var/scoped_accuracy_mod = zoom_offset
 
-	zoom(zoom_offset, view_size)
+	zoom(user, zoom_offset, view_size)
 	if(zoom)
 		accuracy = scoped_accuracy + scoped_accuracy_mod
 		if(recoil)

--- a/Interstation-Two-WW2/code/modules/projectiles/guns/energy/laser.dm
+++ b/Interstation-Two-WW2/code/modules/projectiles/guns/energy/laser.dm
@@ -103,7 +103,7 @@ obj/item/weapon/gun/energy/retro
 	set name = "Use Scope"
 	set popup_menu = 1
 
-	toggle_scope(2.0)
+	toggle_scope(usr, 2.0)
 
 ////////Laser Tag////////////////////
 

--- a/Interstation-Two-WW2/code/modules/projectiles/guns/projectile.dm
+++ b/Interstation-Two-WW2/code/modules/projectiles/guns/projectile.dm
@@ -49,7 +49,7 @@
 	set name = "Use iron sights"
 	set popup_menu = 1
 
-	toggle_scope(1.0)
+	toggle_scope(usr, 1.0)
 
 /obj/item/weapon/gun/projectile/New()
 	..()

--- a/Interstation-Two-WW2/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/Interstation-Two-WW2/code/modules/projectiles/guns/projectile/sniper.dm
@@ -65,5 +65,4 @@
 	set category = "Object"
 	set popup_menu = 1
 
-	toggle_scope(2.0)
-
+	toggle_scope(usr, 2.0)


### PR DESCRIPTION
Addresses #53, changes done to the gun & item code is also applied to non-used assets for downstream or backward compatibility.

* Also fixes a major mistake done in the Maxim gun fix: they now use `show_message` instead of `visible_message` - all `<<` are also replaced with `show_message`.