### PR TITLE
Adds the english meaning of jobs to examine

### DIFF
--- a/Interstation-Two-WW2/code/modules/mob/living/carbon/human/examine.dm
+++ b/Interstation-Two-WW2/code/modules/mob/living/carbon/human/examine.dm
@@ -439,7 +439,7 @@
 		if (ishuman(user))
 			var/mob/living/carbon/human/H = user
 			if (H.original_job.team == original_job.team) // when you ghost, mind.assigned_job is set to null
-				msg += "<br><i>You recognize [T.him] as a [original_job.title].</i>"
+				msg += "<br><i>You recognize [T.him] as a [original_job.title] ([original_job.en_meaning]).</i>"
 		else if (isobserver(user))
 			msg += "<br><i>[T.He] [T.is] a [original_job.title].</i>"
 


### PR DESCRIPTION
Before:
`msg += "<br><i>You recognize [T.him] as a [original_job.title].</i>"`

After:
`msg += "<br><i>You recognize [T.him] as a [original_job.title] ([original_job.en_meaning]).</i>"`

Also, do you guys have a changelog system?